### PR TITLE
remove stats threads

### DIFF
--- a/module/stats_samtools.nf
+++ b/module/stats_samtools.nf
@@ -42,6 +42,6 @@ process run_stats_SAMtools {
 
     """
     set -euo pipefail
-    samtools stats --threads ${task.cpus} ${path} > ${output_filename}_stats.txt
+    samtools stats ${path} > ${output_filename}_stats.txt
     """
 }


### PR DESCRIPTION
# Description
Removing `--threads $task_cpus` from samtools stats command at least for now.  Reasons:
 - it should be based on the number of read groups, and limited by task_cpus
 - it causes problems with `nftest` since the files being checked include the samtools stats command line which will vary with resources requested. 
     - this could be solved with a custom assert script

I have not updated the changelog since the specific addition of `--threads` was not there.

### Closes #...

## Testing Results
`nftest run a_mini-all-tools`
output dir: `/hot/software/pipeline/pipeline-SQC-DNA/Nextflow/development/unreleased/sfitz-remove-stats-threads`
log: `/hot/software/pipeline/pipeline-SQC-DNA/Nextflow/development/unreleased/sfitz-remove-stats-threads/log-nftest-20240118T194219Z.log`

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [ ] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample.
