### PR TITLE
fix CollectWgsMetrics params bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add Nextflow version requirement to `README`
 
 ### Changed
+- Fixed `CollectWgsMetrics` params equal to zero bug
 - Update SAMtools 1.18 to 1.20
 - Update NFTest for FastQC and new test sample
 - Update repository/pipeline description

--- a/module/collectWgsMetrics_picard.nf
+++ b/module/collectWgsMetrics_picard.nf
@@ -32,9 +32,9 @@ process run_CollectWgsMetrics_Picard {
         [:])
     read_length_arg = read_length ? "-READ_LENGTH ${read_length}" : ""
     fast_algorithm_arg = params.cwm_use_fast_algorithm ? "-USE_FAST_ALGORITHM" : ""
-    coverage_cap_arg = params.cwm_coverage_cap ? "-COVERAGE_CAP ${params.cwm_coverage_cap}" : ""
-    minimum_mapping_quality_arg = params.cwm_minimum_mapping_quality ? "-MINIMUM_MAPPING_QUALITY ${params.cwm_minimum_mapping_quality}" : ""
-    minimum_base_quality_arg = params.cwm_minimum_base_quality ? "-MINIMUM_BASE_QUALITY ${params.cwm_minimum_base_quality}" : ""
+    coverage_cap_arg = (params.cwm_coverage_cap != null) ? "-COVERAGE_CAP ${params.cwm_coverage_cap}" : ""
+    minimum_mapping_quality_arg = (params.cwm_minimum_mapping_quality != null) ? "-MINIMUM_MAPPING_QUALITY ${params.cwm_minimum_mapping_quality}" : ""
+    minimum_base_quality_arg = (params.cwm_minimum_base_quality != null) ? "-MINIMUM_BASE_QUALITY ${params.cwm_minimum_base_quality}" : ""
 
     """
     set -euo pipefail


### PR DESCRIPTION
# Description
When these parameters were set to `0` nextflow interpreted the comparison including `params.cwm_minimum_mapping_quality` as `false` and did not set the argument.
This is now fixed by adding `!= null` check.
```
    cwm_minimum_mapping_quality = 0
    cwm_minimum_base_quality = 0
```

## Testing Results
```
    cwm_minimum_mapping_quality = 0
    cwm_minimum_base_quality = 0
```
output:  `/hot/software/pipeline/pipeline-generate-SQC-BAM/Nextflow/development/unreleased/sfitz-fix-cwm-parameter-bug/a_mini-cwm-mq0-fast`
cwm command.sh:  `/hot/software/pipeline/pipeline-generate-SQC-BAM/Nextflow/development/unreleased/sfitz-fix-cwm-parameter-bug/a_mini-cwm-mq0-fast/generate-SQC-BAM-1.0.0/TWGSAMIN000001/log-generate-SQC-BAM-1.0.0-20240722T214851Z/process-log/run_CollectWgsMetrics_Picard-HG002.N/log.command.sh`


# Checklist
<!-- Please read each of the following items and confirm by replacing the [ ] with a [X] -->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD\_username (or 5 letters of AD if AD is too long)]-\[brief\_description\_of\_branch\].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline using NFTest, _or_ I have justified why I did not need to run NFTest above.