### PR TITLE
Update cluster reference paths

### DIFF
--- a/config/template.config
+++ b/config/template.config
@@ -9,7 +9,7 @@ includeConfig "${projectDir}/nextflow.config"
 // Inputs/parameters of the pipeline
 params {
     algorithm = ['stats', 'collectwgsmetrics'] // 'fastqc', 'stats', 'collectwgsmetrics', 'bamqc'
-    reference = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+    reference = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
     output_dir = '/path/to/output/directory'
     blcds_registered_dataset = false // if you want the output to be registered
     save_intermediate_files = true


### PR DESCRIPTION
This PR updates reference paths that were renamed during the most recent cluster downtime.

I was specifically looking for single lines containing one (or more) of the following keys, so I missed any paths split across multiple lines.

| Search String                                                  |
|----------------------------------------------------------------|
| `/hot/ref/`                                                    |
| `/hot/ref/cohort/TCGA/CCG-AIM/`                                |
| `/hot/ref/cohort/TCGA/PanCanAtlas/`                            |
| `/hot/ref/database/1000Genomes/`                               |
| `/hot/ref/database/GDC-34.0 `                                  |
| `/hot/ref/database/GDC-34.0/`                                  |
| `/hot/ref/database/PCAWG/`                                     |
| `/hot/ref/database/ProstateTumor/Boutros-Yamaguchi-PRAD-CPCG/` |
| `/hot/ref/reference/`                                          |
| `/hot/resource/SMC-HET/`                                       |

A table of updated filepaths and whether or not they resolve to a file is included below. Where the original paths still exist due to symlinks I verified that they resolve to the same file as the updated path.

| Original                                                              |                    | Updated                                                                           |                    |
|-----------------------------------------------------------------------|--------------------|-----------------------------------------------------------------------------------|--------------------|
| `/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta` | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta` | :white_check_mark: |